### PR TITLE
Tag all Flamework functions.

### DIFF
--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -1,3 +1,4 @@
+import Object from "@rbxts/object-utils";
 import { Players, RunService } from "@rbxts/services";
 import { t } from "@rbxts/t";
 import { Modding } from "./modding";
@@ -98,6 +99,11 @@ export namespace Flamework {
 		return "new" in obj && "constructor" in obj;
 	}
 
+	function getIdentifier(obj: object, suffix = ""): string {
+		const baseIdentifier = Reflect.getMetadata<string>(obj, "identifier") ?? "UnidentifiedFlameworkListener";
+		return baseIdentifier + suffix;
+	}
+
 	const externalClasses = new Set<Constructor>();
 
 	/**
@@ -170,24 +176,9 @@ export namespace Flamework {
 
 		dependencies.sort(([, a], [, b]) => (a.loadOrder ?? 1) < (b.loadOrder ?? 1));
 
-		Modding.onListenerAdded<OnTick>((object) =>
-			tick.set(
-				object,
-				Reflect.getMetadata<string>(object, "identifier") ?? "UnidentifiedFlameworkListener@onTick",
-			),
-		);
-		Modding.onListenerAdded<OnPhysics>((object) =>
-			physics.set(
-				object,
-				Reflect.getMetadata<string>(object, "identifier") ?? "UnidentifiedFlameworkListener@onPhysics",
-			),
-		);
-		Modding.onListenerAdded<OnRender>((object) =>
-			render.set(
-				object,
-				Reflect.getMetadata<string>(object, "identifier") ?? "UnidentifiedFlameworkListener@onRender",
-			),
-		);
+		Modding.onListenerAdded<OnTick>((object) => tick.set(object, getIdentifier(object, "@OnTick")));
+		Modding.onListenerAdded<OnPhysics>((object) => physics.set(object, getIdentifier(object, "@OnPhysics")));
+		Modding.onListenerAdded<OnRender>((object) => render.set(object, getIdentifier(object, "@OnRender")));
 
 		Modding.onListenerRemoved<OnTick>((object) => tick.delete(object));
 		Modding.onListenerRemoved<OnPhysics>((object) => physics.delete(object));
@@ -195,10 +186,10 @@ export namespace Flamework {
 
 		for (const [dependency] of dependencies) {
 			if (Flamework.implements<OnInit>(dependency)) {
-				init.set(dependency, Reflect.getMetadata<string>(dependency as object, "identifier")!);
+				init.set(dependency, getIdentifier(dependency));
 			}
 			if (Flamework.implements<OnStart>(dependency)) {
-				start.set(dependency, Reflect.getMetadata<string>(dependency as object, "identifier")!);
+				start.set(dependency, getIdentifier(dependency));
 			}
 		}
 

--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -1,4 +1,3 @@
-import Object from "@rbxts/object-utils";
 import { Players, RunService } from "@rbxts/services";
 import { t } from "@rbxts/t";
 import { Modding } from "./modding";

--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -196,20 +196,29 @@ export namespace Flamework {
 
 		RunService.Heartbeat.Connect((dt) => {
 			for (const dependency of tick) {
-				task.spawn(() => dependency.onTick(dt));
+				task.spawn(() => {
+					debug.setmemorycategory(Reflect.getMetadata<string>(dependency, "identifier")!);
+					dependency.onTick(dt);
+				});
 			}
 		});
 
 		RunService.Stepped.Connect((time, dt) => {
 			for (const dependency of physics) {
-				task.spawn(() => dependency.onPhysics(dt, time));
+				task.spawn(() => {
+					debug.setmemorycategory(Reflect.getMetadata<string>(dependency, "identifier")!);
+					dependency.onPhysics(dt, time);
+				});
 			}
 		});
 
 		if (RunService.IsClient()) {
 			RunService.RenderStepped.Connect((dt) => {
 				for (const dependency of render) {
-					task.spawn(() => dependency.onRender(dt));
+					task.spawn(() => {
+						debug.setmemorycategory(Reflect.getMetadata<string>(dependency, "identifier")!);
+						dependency.onRender(dt);
+					});
 				}
 			});
 		}

--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -185,12 +185,8 @@ export namespace Flamework {
 		Modding.onListenerRemoved<OnRender>((object) => render.delete(object));
 
 		for (const [dependency] of dependencies) {
-			if (Flamework.implements<OnInit>(dependency)) {
-				init.set(dependency, getIdentifier(dependency));
-			}
-			if (Flamework.implements<OnStart>(dependency)) {
-				start.set(dependency, getIdentifier(dependency));
-			}
+			if (Flamework.implements<OnInit>(dependency)) init.set(dependency, getIdentifier(dependency));
+			if (Flamework.implements<OnStart>(dependency)) start.set(dependency, getIdentifier(dependency));
 		}
 
 		for (const [dependency, indentifier] of init) {


### PR DESCRIPTION
We have found that it can be valuable to know the memory consumption of the onTick, onPhysics, and onRender functions as well as the onStart and onInit functions. This PR adds additional memory tagging under the same dependency identifier.