### PR TITLE
Move `Flamework.ComponentConfig` to `@flamework/components`

### DIFF
--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -5,13 +5,6 @@ import { Reflect } from "./reflect";
 import { Constructor } from "./types";
 
 export namespace Flamework {
-	export interface ComponentConfig {
-		tag?: string;
-		attributes?: { [key: string]: t.check<unknown> };
-		defaults?: { [key: string]: unknown };
-		instanceGuard?: t.check<unknown>;
-		refreshAttributes?: boolean;
-	}
 	export interface ServiceConfig {
 		loadOrder?: number;
 	}


### PR DESCRIPTION
Breaking change, but unlikely anyone is actually importing it manually.

Related: https://github.com/rbxts-flamework/components/pull/5