### PR TITLE
Revise external singletons

### DIFF
--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -173,7 +173,7 @@ export namespace Flamework {
 	/**
 	 * Explicitly include an optional class in the startup cycle.
 	 */
-	export function registerOptionalClass(ctor: Constructor) {
+	export function includeOptionalClass(ctor: Constructor) {
 		Reflect.defineMetadata(ctor, "flamework:optional", false);
 	}
 

--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -366,6 +366,11 @@ export const Controller = Modding.createDecorator<[opts?: Flamework.ControllerCo
  * This singleton will only be included if it is depended on or is explicitly included with `Flamework.registerOptionalClass`.
  */
 export const Optional = Modding.createDecorator("Class", (descriptor) => {
+	if (!Reflect.getMetadata<boolean>(descriptor.object, "flamework:singleton")) {
+		warn("'Optional' decorator was applied to a non-singleton.", descriptor.object);
+		warn("Make sure you apply the 'Optional' decorator above other decorators.");
+	}
+
 	Reflect.defineMetadata(descriptor.object, `flamework:optional`, true);
 });
 

--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -363,7 +363,7 @@ export const Controller = Modding.createDecorator<[opts?: Flamework.ControllerCo
 /**
  * Marks a singleton as optional.
  *
- * This singleton will only be included if it is depended on or is explicitly included with `Flamework.registerOptionalClass`.
+ * This singleton will only be included if it is depended on or is explicitly included with `Flamework.includeOptionalClass`.
  */
 export const Optional = Modding.createDecorator("Class", (descriptor) => {
 	if (!Reflect.getMetadata<boolean>(descriptor.object, "flamework:singleton")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { Modding } from "./modding";
 export {
 	Controller,
 	Dependency,
-	External,
+	Optional,
 	Service,
 	Flamework,
 	OnInit,


### PR DESCRIPTION
BREAKING: Renames the `@External` decorator to `@Optional` to better communicate intent.
BREAKING: Renames `registerExternalClass` to `includeOptionalClass` for the same reason.