### PR TITLE
Add ID lookup function to modding API

### DIFF
--- a/src/modding.ts
+++ b/src/modding.ts
@@ -70,6 +70,15 @@ export namespace Modding {
 	const loadingList = new Array<Constructor>();
 
 	/**
+	 * Retrieves an object from its identifier.
+	 *
+	 * The reverse (getting an identifier from an object) can be achieved using the Reflect API directly.
+	 */
+	export function getObjectFromId(id: string) {
+		return Reflect.idToObj.get(id);
+	}
+
+	/**
 	 * Registers a listener for lifecycle events.
 	 */
 	export function addListener(object: object) {

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -11,6 +11,8 @@ export namespace Reflect {
 
 	/** @internal */
 	export const decorators = new Map<string, Array<AbstractConstructor>>();
+
+	/** @internal */
 	export const idToObj = new Map<string, object>();
 
 	const NO_PROP_MARKER = {} as { _nominal_Marker: never };


### PR DESCRIPTION
BREAKING: Removes `Reflect.idToObj` to remove Flamework-specific APIs from the `Reflect` namespace