### PR TITLE
Standardize macros

### DIFF
--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -23,7 +23,7 @@ export namespace Flamework {
 	let inactiveThread: thread | undefined;
 
 	/** @hidden */
-	export function resolveDependency(id: string) {
+	export function resolveDependency<T>(id: string) {
 		if (isPreloading) {
 			const [source, line] = debug.info(2, "sl");
 			warn(`[Flamework] Attempting to load dependency '${id}' during preloading.`);
@@ -36,7 +36,7 @@ export namespace Flamework {
 			warn("You can disable this warning in flamework.json");
 			warn(`Script '${source}', Line ${line}`);
 		}
-		return Modding.resolveDependency(ArtificialDependency, id, 0, {});
+		return Modding.resolveDependency(ArtificialDependency, id, 0, {}) as T;
 	}
 
 	/** @hidden */
@@ -354,8 +354,10 @@ Reflect.defineMetadata(ArtificialDependency, "flamework:isArtificial", true);
  *
  * This function can make it harder to stub, test or modify your code so it is recommended to use this macro minimally.
  * It is recommended that you pass dependencies to code that needs it from a singleton, component, etc.
+ *
+ * @metadata macro {@link Flamework.resolveDependency intrinsic-flamework-rewrite}
  */
-export declare function Dependency<T>(ctor?: Constructor<T>): T;
+export declare function Dependency<T>(id?: IntrinsicSymbolId<T>): T;
 
 /**
  * Register a class as a Service.

--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -327,8 +327,9 @@ export namespace Flamework {
 	 * if the specified string does not have one in that context.
 	 * @param str The string to hash
 	 * @param context A scope for the hash
+	 * @metadata macro {@link meta intrinsic-inline}
 	 */
-	export declare function hash(str: string, context?: string): string;
+	export declare function hash<T extends string, C extends string = never>(meta?: Modding.Hash<T, C>): string;
 }
 
 /**

--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -317,11 +317,6 @@ export namespace Flamework {
 	export declare function implements<T>(object: unknown): object is T;
 
 	/**
-	 * Creates a type guard from any arbitrary type.
-	 */
-	export declare function createGuard<T>(): t.check<T>;
-
-	/**
 	 * Hash a function using the method used internally by Flamework.
 	 * If a context is provided, then Flamework will create a new hash
 	 * if the specified string does not have one in that context.
@@ -330,6 +325,14 @@ export namespace Flamework {
 	 * @metadata macro {@link meta intrinsic-inline}
 	 */
 	export declare function hash<T extends string, C extends string = never>(meta?: Modding.Hash<T, C>): string;
+
+	/**
+	 * Creates a type guard from any arbitrary type.
+	 * @metadata macro
+	 */
+	export function createGuard<T>(meta?: Modding.Generic<T, "guard">): t.check<T> {
+		return meta!;
+	}
 }
 
 /**

--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -303,8 +303,10 @@ export namespace Flamework {
 
 	/**
 	 * Retrieve the identifier for the specified type.
+	 *
+	 * @metadata macro {@link id intrinsic-inline}
 	 */
-	export declare function id<T>(): string;
+	export declare function id<T>(id?: IntrinsicSymbolId<T>): string;
 
 	/**
 	 * Check if the constructor implements the specified interface.

--- a/src/flamework.ts
+++ b/src/flamework.ts
@@ -3,7 +3,7 @@ import { t } from "@rbxts/t";
 import { Metadata } from "./metadata";
 import { Modding } from "./modding";
 import { Reflect } from "./reflect";
-import { AbstractConstructor, Constructor, isConstructor } from "./utility";
+import { AbstractConstructor, Constructor, IntrinsicSymbolId, isConstructor } from "./utility";
 
 export namespace Flamework {
 	export interface ServiceConfig {
@@ -308,13 +308,17 @@ export namespace Flamework {
 
 	/**
 	 * Check if the constructor implements the specified interface.
+	 *
+	 * @metadata macro {@link _implements intrinsic-flamework-rewrite}
 	 */
-	export declare function implements<T>(object: AbstractConstructor): boolean;
+	export declare function implements<T>(object: AbstractConstructor, id?: IntrinsicSymbolId<T>): boolean;
 
 	/**
 	 * Check if object implements the specified interface.
+	 *
+	 * @metadata macro {@link _implements intrinsic-flamework-rewrite}
 	 */
-	export declare function implements<T>(object: unknown): object is T;
+	export declare function implements<T>(object: unknown, id?: IntrinsicSymbolId<T>): object is T;
 
 	/**
 	 * Hash a function using the method used internally by Flamework.
@@ -328,6 +332,7 @@ export namespace Flamework {
 
 	/**
 	 * Creates a type guard from any arbitrary type.
+	 *
 	 * @metadata macro
 	 */
 	export function createGuard<T>(meta?: Modding.Generic<T, "guard">): t.check<T> {

--- a/src/modding.ts
+++ b/src/modding.ts
@@ -518,23 +518,6 @@ export namespace Modding {
 	}
 
 	/**
-	 * @hidden
-	 * @deprecated
-	 */
-	export function macro<T>(values: string | [string, unknown][], directValue?: unknown): T {
-		if (typeIs(values, "string")) {
-			return {
-				[values]: directValue,
-			} as never;
-		}
-		const result = {} as Record<string, unknown>;
-		for (const [name, value] of values) {
-			result[name] = value;
-		}
-		return result as T;
-	}
-
-	/**
 	 * This API allows you to use more complex queries, inspect types, generate arbitrary objects based on types, etc.
 	 *
 	 * @experimental This API is considered experimental and may change.

--- a/src/modding.ts
+++ b/src/modding.ts
@@ -556,16 +556,26 @@ export namespace Modding {
 	/**
 	 * Retrieves metadata about the specified type using Flamework's user macros.
 	 */
-	export type Generic<T, M extends keyof GenericMetadata<T>> = Pick<GenericMetadata<T>, M> & {
-		/** @hidden */ _flamework_macro_generic: [T, { [k in M]: k }];
+	export type Generic<T, M extends keyof GenericMetadata<T>> = GenericMetadata<T>[M] & {
+		/** @hidden */ _flamework_macro_generic: [T, M];
 	};
+
+	/**
+	 * Retrieves multiple types of metadata from Flamework's user macros.
+	 */
+	export type GenericMany<T, M extends keyof GenericMetadata<T>> = Modding.Many<{ [k in M]: Generic<T, k> }>;
 
 	/**
 	 * Retrieves metadata about the callsite using Flamework's user macros.
 	 */
-	export type Caller<M extends keyof CallerMetadata> = Pick<CallerMetadata, M> & {
-		/** @hidden */ _flamework_macro_caller: { [k in M]: k };
+	export type Caller<M extends keyof CallerMetadata> = CallerMetadata[M] & {
+		/** @hidden */ _flamework_macro_caller: M;
 	};
+
+	/**
+	 * Retrieves multiple types of metadata about the callsite using Flamework's user macros.
+	 */
+	export type CallerMany<M extends keyof CallerMetadata> = Modding.Many<{ [k in M]: Caller<k> }>;
 
 	/**
 	 * An internal type for intrinsic user macro metadata.

--- a/src/modding.ts
+++ b/src/modding.ts
@@ -1,6 +1,6 @@
 import Signal from "@rbxts/signal";
 import { Reflect } from "./reflect";
-import { AbstractConstructor, Constructor, isConstructor } from "./utility";
+import { AbstractConstructor, Constructor, IntrinsicSymbolId, isConstructor } from "./utility";
 import type { Flamework } from "./flamework";
 import { t } from "@rbxts/t";
 
@@ -152,16 +152,23 @@ export namespace Modding {
 	 * Fires whenever a listener has a decorator with the specified ID.
 	 *
 	 * Fires for all existing listeners.
+	 *
+	 * @metadata macro
 	 */
-	export function onListenerAdded<T extends AnyDecorator>(func: ListenerAddedEvent, id?: string): RBXScriptConnection;
+	export function onListenerAdded<T extends AnyDecorator>(
+		func: ListenerAddedEvent,
+		id?: IntrinsicSymbolId<T>,
+	): RBXScriptConnection;
 
 	/**
 	 * Registers a listener added event.
 	 * Fires whenever a listener has a lifecycle event with the specified ID.
 	 *
 	 * Fires for all existing listeners.
+	 *
+	 * @metadata macro
 	 */
-	export function onListenerAdded<T>(func: (value: T) => void, id?: string): RBXScriptConnection;
+	export function onListenerAdded<T>(func: (value: T) => void, id?: IntrinsicSymbolId<T>): RBXScriptConnection;
 
 	/**
 	 * Registers a listener added event.
@@ -198,15 +205,22 @@ export namespace Modding {
 	 * Registers a listener removed event.
 	 *
 	 * Fires whenever a listener has a decorator with the specified ID.
+	 *
+	 * @metadata macro
 	 */
-	export function onListenerRemoved<T extends AnyDecorator>(func: ListenerRemovedEvent): RBXScriptConnection;
+	export function onListenerRemoved<T extends AnyDecorator>(
+		func: ListenerRemovedEvent,
+		id?: IntrinsicSymbolId<T>,
+	): RBXScriptConnection;
 
 	/**
 	 * Registers a listener removed event.
 	 *
 	 * Fires whenever a listener has a lifecycle event with the specified ID.
+	 *
+	 * @metadata macro
 	 */
-	export function onListenerRemoved<T>(func: (object: T) => void, id?: string): RBXScriptConnection;
+	export function onListenerRemoved<T>(func: (object: T) => void, id?: IntrinsicSymbolId<T>): RBXScriptConnection;
 
 	/**
 	 * Registers a listener removed event.
@@ -297,8 +311,12 @@ export namespace Modding {
 
 	/**
 	 * Retrieves registered decorators.
+	 *
+	 * @metadata macro
 	 */
-	export function getDecorators<T extends AnyDecorator>(id?: string): AttachedDecorator<DecoratorParameters<T>>[] {
+	export function getDecorators<T extends AnyDecorator>(
+		id?: IntrinsicSymbolId<T>,
+	): AttachedDecorator<DecoratorParameters<T>>[] {
 		assert(id !== undefined);
 
 		const decorators = Reflect.decorators.get(id);
@@ -318,10 +336,12 @@ export namespace Modding {
 
 	/**
 	 * Creates a map of every property using the specified decorator.
+	 *
+	 * @metadata macro
 	 */
 	export function getPropertyDecorators<T extends AnyDecorator>(
 		obj: object,
-		id?: string,
+		id?: IntrinsicSymbolId<T>,
 	): Map<string, { arguments: DecoratorParameters<T> }> {
 		const decorators = new Map<string, { arguments: DecoratorParameters<T> }>();
 		assert(id !== undefined);
@@ -338,11 +358,13 @@ export namespace Modding {
 
 	/**
 	 * Retrieves a decorator from an object or its properties.
+	 *
+	 * @metadata macro
 	 */
 	export function getDecorator<T extends AnyDecorator>(
 		object: object,
 		property?: string,
-		id?: string,
+		id?: IntrinsicSymbolId<T>,
 	): { arguments: DecoratorParameters<T> } | undefined {
 		const decorator = Reflect.getMetadata<Flamework.Decorator>(object, `flamework:decorators.${id}`, property);
 		if (!decorator) return;
@@ -380,8 +402,10 @@ export namespace Modding {
 	 *
 	 * If a function is passed, it will be called, passing the target constructor, every time that ID needs to be resolved.
 	 * Otherwise, the passed object is returned directly.
+	 *
+	 * @metadata macro
 	 */
-	export function registerDependency<T>(dependency: DependencyRegistration, id?: string) {
+	export function registerDependency<T>(dependency: DependencyRegistration, id?: IntrinsicSymbolId<T>) {
 		assert(id !== undefined);
 
 		if (typeIs(dependency, "function")) {

--- a/src/modding.ts
+++ b/src/modding.ts
@@ -157,7 +157,7 @@ export namespace Modding {
 	 */
 	export function onListenerAdded<T extends AnyDecorator>(
 		func: ListenerAddedEvent,
-		id?: IntrinsicSymbolId<T>,
+		id?: IdRef<T>,
 	): RBXScriptConnection;
 
 	/**
@@ -168,7 +168,7 @@ export namespace Modding {
 	 *
 	 * @metadata macro
 	 */
-	export function onListenerAdded<T>(func: (value: T) => void, id?: IntrinsicSymbolId<T>): RBXScriptConnection;
+	export function onListenerAdded<T>(func: (value: T) => void, id?: IdRef<T>): RBXScriptConnection;
 
 	/**
 	 * Registers a listener added event.
@@ -210,7 +210,7 @@ export namespace Modding {
 	 */
 	export function onListenerRemoved<T extends AnyDecorator>(
 		func: ListenerRemovedEvent,
-		id?: IntrinsicSymbolId<T>,
+		id?: IdRef<T>,
 	): RBXScriptConnection;
 
 	/**
@@ -220,7 +220,7 @@ export namespace Modding {
 	 *
 	 * @metadata macro
 	 */
-	export function onListenerRemoved<T>(func: (object: T) => void, id?: IntrinsicSymbolId<T>): RBXScriptConnection;
+	export function onListenerRemoved<T>(func: (object: T) => void, id?: IdRef<T>): RBXScriptConnection;
 
 	/**
 	 * Registers a listener removed event.
@@ -314,9 +314,7 @@ export namespace Modding {
 	 *
 	 * @metadata macro
 	 */
-	export function getDecorators<T extends AnyDecorator>(
-		id?: IntrinsicSymbolId<T>,
-	): AttachedDecorator<DecoratorParameters<T>>[] {
+	export function getDecorators<T extends AnyDecorator>(id?: IdRef<T>): AttachedDecorator<DecoratorParameters<T>>[] {
 		assert(id !== undefined);
 
 		const decorators = Reflect.decorators.get(id);
@@ -341,7 +339,7 @@ export namespace Modding {
 	 */
 	export function getPropertyDecorators<T extends AnyDecorator>(
 		obj: object,
-		id?: IntrinsicSymbolId<T>,
+		id?: IdRef<T>,
 	): Map<string, { arguments: DecoratorParameters<T> }> {
 		const decorators = new Map<string, { arguments: DecoratorParameters<T> }>();
 		assert(id !== undefined);
@@ -364,7 +362,7 @@ export namespace Modding {
 	export function getDecorator<T extends AnyDecorator>(
 		object: object,
 		property?: string,
-		id?: IntrinsicSymbolId<T>,
+		id?: IdRef<T>,
 	): { arguments: DecoratorParameters<T> } | undefined {
 		const decorator = Reflect.getMetadata<Flamework.Decorator>(object, `flamework:decorators.${id}`, property);
 		if (!decorator) return;
@@ -405,7 +403,7 @@ export namespace Modding {
 	 *
 	 * @metadata macro
 	 */
-	export function registerDependency<T>(dependency: DependencyRegistration, id?: IntrinsicSymbolId<T>) {
+	export function registerDependency<T>(dependency: DependencyRegistration, id?: IdRef<T>) {
 		assert(id !== undefined);
 
 		if (typeIs(dependency, "function")) {
@@ -672,6 +670,8 @@ export namespace Modding {
 		 */
 		guard: t.check<T>;
 	}
+
+	type IdRef<T> = string | IntrinsicSymbolId<T>;
 }
 
 interface DependencyResolutionOptions {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,5 +1,10 @@
+import type { Modding } from "./modding";
+
 export type Constructor<T = object> = new (...args: never[]) => T;
 export type AbstractConstructor<T = object> = abstract new (...args: never[]) => T;
+
+/** @hidden */
+export type IntrinsicSymbolId<T> = Modding.Intrinsic<"symbol-id", [T], string>;
 
 export function isConstructor(obj: object): obj is Constructor {
 	return isAbstractConstructor(obj) && "new" in obj;


### PR DESCRIPTION
BREAKING: `Modding.Generic` has been renamed to `Modding.GenericMany` and replaced with an API to get a single type of metadata.
BREAKING: `Modding.Caller` has been renamed to `Modding.CallerMany` and replaced with an API to get a single type of metadata.
BREAKING: `Flamework.Hash` has been changed to use type arguments instead of parameters, so it is now `Flamework.Hash<"abc">` instead of `Flamework.hash("abc")`
BREAKING: `Dependency(T)` alternate syntax has been removed and `Dependency<T>()` should be used instead.

https://github.com/rbxts-flamework/transformer/pull/36