### PR TITLE
Update default `@rbxts/t` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@rbxts/object-utils": "^1.0.4",
         "@rbxts/services": "^1.1.4",
         "@rbxts/signal": "^1.0.3",
-        "@rbxts/t": "^2.1.4"
+        "@rbxts/t": "^3.1.0"
       },
       "devDependencies": {
         "@rbxts/compiler-types": "^2.2.0-types.0",
@@ -219,9 +219,9 @@
       }
     },
     "node_modules/@rbxts/t": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@rbxts/t/-/t-2.1.4.tgz",
-      "integrity": "sha512-DjDoh3NkcM3fmJDjwrcJaSKJu6oykUvJnZK2voRgZLlfb/8Nk4MNAlYLsuBiSexJA/q89+kOa8YzS/WN7Ysdow=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rbxts/t/-/t-3.1.0.tgz",
+      "integrity": "sha512-ba/wfKYtAL6JWVhZNbhMnBZtzgGaTxttvfzxxpEcHDy0Qeaq0DF2Odo/zJ32Ajw961EMYkAMTnPXLLrLB/r+mw=="
     },
     "node_modules/@rbxts/types": {
       "version": "1.0.666",
@@ -2884,9 +2884,9 @@
       "requires": {}
     },
     "@rbxts/t": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@rbxts/t/-/t-2.1.4.tgz",
-      "integrity": "sha512-DjDoh3NkcM3fmJDjwrcJaSKJu6oykUvJnZK2voRgZLlfb/8Nk4MNAlYLsuBiSexJA/q89+kOa8YzS/WN7Ysdow=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rbxts/t/-/t-3.1.0.tgz",
+      "integrity": "sha512-ba/wfKYtAL6JWVhZNbhMnBZtzgGaTxttvfzxxpEcHDy0Qeaq0DF2Odo/zJ32Ajw961EMYkAMTnPXLLrLB/r+mw=="
     },
     "@rbxts/types": {
       "version": "1.0.666",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "@rbxts/object-utils": "^1.0.4",
     "@rbxts/services": "^1.1.4",
     "@rbxts/signal": "^1.0.3",
-    "@rbxts/t": "^2.1.4"
+    "@rbxts/t": "^3.1.0"
   }
 }


### PR DESCRIPTION
`@rbxts/t` 3.0 does not introduce any breaking changes, so this shouldn't affect any projects. Flamework will continue to use any existing `@rbxts/t` installation.